### PR TITLE
[Protocol 2] Re-Implement Brokers for Dolomite (#454)

### DIFF
--- a/packages/loopring_v2/contracts/helper/MiningHelper.sol
+++ b/packages/loopring_v2/contracts/helper/MiningHelper.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../impl/Data.sol";
 import "../lib/MultihashUtil.sol";

--- a/packages/loopring_v2/contracts/helper/ParticipationHelper.sol
+++ b/packages/loopring_v2/contracts/helper/ParticipationHelper.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../impl/Data.sol";
 import "../lib/MathUint.sol";
@@ -167,10 +167,6 @@ library ParticipationHelper {
         uint totalAmountFee = p.feeAmount;
         p.order.tokenSpendableS.amount = p.order.tokenSpendableS.amount.sub(totalAmountS);
         p.order.tokenSpendableFee.amount = p.order.tokenSpendableFee.amount.sub(totalAmountFee);
-        if (p.order.brokerInterceptor != address(0x0)) {
-            p.order.brokerSpendableS.amount = p.order.brokerSpendableS.amount.sub(totalAmountS);
-            p.order.brokerSpendableFee.amount = p.order.brokerSpendableFee.amount.sub(totalAmountFee);
-        }
     }
 
     function revertOrderState(

--- a/packages/loopring_v2/contracts/iface/Errors.sol
+++ b/packages/loopring_v2/contracts/iface/Errors.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title Errors

--- a/packages/loopring_v2/contracts/iface/IBrokerDelegate.sol
+++ b/packages/loopring_v2/contracts/iface/IBrokerDelegate.sol
@@ -1,0 +1,64 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity 0.5.7;
+
+/**
+ * @title IBrokerDelegate
+ * @author Zack Rubenstein
+ */
+interface IBrokerDelegate {
+
+  /*
+   * Set the allowance on the given token for the specified amount, assuming the 
+   * balance attributed to the owner is sufficient.
+   *
+   * This gets called individually for each transfer required of the broker.
+   * Loopring's RingSubmitter calls this and then performs a transfer on the
+   * broker's token balance. If the tokens for the given owner address are
+   * held in a different contract, they must be moved into the broker's possesion
+   * in the execution of this function. A transfer will not occur if the requestedRecipient
+   * is equal to this broker address, you must handle this case internally if applicable.
+   * Furthermore, it is highly encouraged that one requires that the msg.sender is the
+   * Loopring RingSubmitter contract to ensure the security of funds held in this contract.
+   *
+   * owner - the owner of the order who's attributed funds are being requested
+   * receivedToken - The token that was received (tokenB)
+   * receivedAmount - The amount of the token that was received (amountB)
+   * orderTokenRecipient - the tokenRecipient of the order (this is who received the receivedAmount)
+   * requestedToken - The token who's approval is being requested (tokenS/feeToken)
+   * requestedAmount - The requested amount to be transferred
+   * requestedRecipient - The recipient of the requested funds
+   * extraOrderData - The transferDataS field of the order
+   * isFee - if this is for a fee. If this is true, receivedToken & receivedAmount will be 0 and 0x0
+   */
+  function brokerRequestAllowance(
+    address owner, 
+    address receivedToken,
+    uint receivedAmount,
+    address orderTokenRecipient,
+    address requestedToken, 
+    uint requestedAmount, 
+    address requestedRecipient,
+    bytes calldata extraOrderData,
+    bool isFee
+  ) external;
+
+  /*
+   * Get the available token balance controlled by the broker on behalf of an address (owner)
+   */
+  function brokerBalanceOf(address owner, address token) external view returns (uint);
+}

--- a/packages/loopring_v2/contracts/iface/IBrokerInterceptor.sol
+++ b/packages/loopring_v2/contracts/iface/IBrokerInterceptor.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IBrokerInterceptor

--- a/packages/loopring_v2/contracts/iface/IBrokerRegistry.sol
+++ b/packages/loopring_v2/contracts/iface/IBrokerRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IBrokerRegistry

--- a/packages/loopring_v2/contracts/iface/IBurnRateTable.sol
+++ b/packages/loopring_v2/contracts/iface/IBurnRateTable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @author Brecht Devos - <brecht@loopring.org>

--- a/packages/loopring_v2/contracts/iface/IFeeHolder.sol
+++ b/packages/loopring_v2/contracts/iface/IFeeHolder.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @author Kongliang Zhong - <kongliang@loopring.org>

--- a/packages/loopring_v2/contracts/iface/IOrderBook.sol
+++ b/packages/loopring_v2/contracts/iface/IOrderBook.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IOrderBook

--- a/packages/loopring_v2/contracts/iface/IOrderCanceller.sol
+++ b/packages/loopring_v2/contracts/iface/IOrderCanceller.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IOrderCanceller

--- a/packages/loopring_v2/contracts/iface/IOrderRegistry.sol
+++ b/packages/loopring_v2/contracts/iface/IOrderRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IOrderRegistry

--- a/packages/loopring_v2/contracts/iface/IRingSubmitter.sol
+++ b/packages/loopring_v2/contracts/iface/IRingSubmitter.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title IRingSubmitter

--- a/packages/loopring_v2/contracts/iface/ITradeDelegate.sol
+++ b/packages/loopring_v2/contracts/iface/ITradeDelegate.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title ITradeDelegate

--- a/packages/loopring_v2/contracts/iface/ITradeHistory.sol
+++ b/packages/loopring_v2/contracts/iface/ITradeHistory.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title ITradeHistory

--- a/packages/loopring_v2/contracts/impl/BrokerInterceptorProxy.sol
+++ b/packages/loopring_v2/contracts/impl/BrokerInterceptorProxy.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IBrokerInterceptor.sol";
 

--- a/packages/loopring_v2/contracts/impl/BrokerRegistry.sol
+++ b/packages/loopring_v2/contracts/impl/BrokerRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 import "../iface/IBrokerRegistry.sol";

--- a/packages/loopring_v2/contracts/impl/BurnManager.sol
+++ b/packages/loopring_v2/contracts/impl/BurnManager.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IFeeHolder.sol";
 import "../lib/ERC20SafeTransfer.sol";

--- a/packages/loopring_v2/contracts/impl/BurnRateTable.sol
+++ b/packages/loopring_v2/contracts/impl/BurnRateTable.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IBurnRateTable.sol";
 import "../lib/ERC20.sol";

--- a/packages/loopring_v2/contracts/impl/Data.sol
+++ b/packages/loopring_v2/contracts/impl/Data.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IBrokerRegistry.sol";
 import "../iface/IBurnRateTable.sol";
@@ -36,6 +36,17 @@ library Data {
         uint numSpendables;
     }
 
+    struct BrokerTransfer {
+        uint orderIndex;
+        address owner;
+        address broker;
+        bool isFee;
+        uint receivedAmount;
+        address token;
+        address recipient;
+        uint amount;
+    }
+
     struct Context {
         address lrcTokenAddress;
         ITradeDelegate  delegate;
@@ -52,6 +63,8 @@ library Data {
         uint feePtr;
         uint transferData;
         uint transferPtr;
+        BrokerTransfer[] brokerTransfers;
+        uint numBrokerTransfers;
     }
 
     struct Mining {
@@ -124,6 +137,7 @@ library Data {
     struct Participation {
         // required fields
         Order order;
+        uint orderIndex;
 
         // computed fields
         uint splitS;

--- a/packages/loopring_v2/contracts/impl/ExchangeDeserializer.sol
+++ b/packages/loopring_v2/contracts/impl/ExchangeDeserializer.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../lib/BytesUtil.sol";
 import "./Data.sol";
@@ -411,7 +411,7 @@ library ExchangeDeserializer {
     {
         uint ringsArrayDataSize = (1 + numRings) * 32;
         uint ringStructSize = 5 * 32;
-        uint participationStructSize = 10 * 32;
+        uint participationStructSize = 11 * 32;
 
         assembly {
             // Allocate memory for all rings
@@ -470,16 +470,19 @@ library ExchangeDeserializer {
                         mload(add(orders, mul(add(orderIndex, 1), 32)))
                     )
 
+                    // participation.orderIndex
+                    mstore(add(participation,  32), orderIndex) 
+
                     // Set default values
-                    mstore(add(participation,  32), 0)          // participation.splitS
-                    mstore(add(participation,  64), 0)          // participation.feeAmount
-                    mstore(add(participation,  96), 0)          // participation.feeAmountS
-                    mstore(add(participation, 128), 0)          // participation.feeAmountB
-                    mstore(add(participation, 160), 0)          // participation.rebateFee
-                    mstore(add(participation, 192), 0)          // participation.rebateS
-                    mstore(add(participation, 224), 0)          // participation.rebateB
-                    mstore(add(participation, 256), 0)          // participation.fillAmountS
-                    mstore(add(participation, 288), 0)          // participation.fillAmountB
+                    mstore(add(participation,  64), 0)          // participation.splitS
+                    mstore(add(participation,  96), 0)          // participation.feeAmount
+                    mstore(add(participation, 128), 0)          // participation.feeAmountS
+                    mstore(add(participation, 160), 0)          // participation.feeAmountB
+                    mstore(add(participation, 192), 0)          // participation.rebateFee
+                    mstore(add(participation, 224), 0)          // participation.rebateS
+                    mstore(add(participation, 256), 0)          // participation.rebateB
+                    mstore(add(participation, 288), 0)          // participation.fillAmountS
+                    mstore(add(participation, 320), 0)          // participation.fillAmountB
                 }
 
                 // Advance to the next ring

--- a/packages/loopring_v2/contracts/impl/FeeHolder.sol
+++ b/packages/loopring_v2/contracts/impl/FeeHolder.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IFeeHolder.sol";
 import "../iface/ITradeDelegate.sol";

--- a/packages/loopring_v2/contracts/impl/Migrations.sol
+++ b/packages/loopring_v2/contracts/impl/Migrations.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 contract Migrations {

--- a/packages/loopring_v2/contracts/impl/OrderBook.sol
+++ b/packages/loopring_v2/contracts/impl/OrderBook.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../helper/OrderHelper.sol";
 import "../iface/IOrderBook.sol";

--- a/packages/loopring_v2/contracts/impl/OrderCanceller.sol
+++ b/packages/loopring_v2/contracts/impl/OrderCanceller.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IOrderCanceller.sol";
 import "../iface/ITradeHistory.sol";

--- a/packages/loopring_v2/contracts/impl/OrderRegistry.sol
+++ b/packages/loopring_v2/contracts/impl/OrderRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IOrderRegistry.sol";
 import "../lib/NoDefaultFunc.sol";

--- a/packages/loopring_v2/contracts/impl/PublicExchangeDeserializer.sol
+++ b/packages/loopring_v2/contracts/impl/PublicExchangeDeserializer.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "./ExchangeDeserializer.sol";
 

--- a/packages/loopring_v2/contracts/impl/RingSubmitter.sol
+++ b/packages/loopring_v2/contracts/impl/RingSubmitter.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../helper/MiningHelper.sol";
 import "../helper/OrderHelper.sol";
@@ -28,10 +28,12 @@ import "../iface/IOrderBook.sol";
 import "../iface/IRingSubmitter.sol";
 import "../iface/ITradeDelegate.sol";
 import "../iface/ITradeHistory.sol";
+import "../iface/IBrokerDelegate.sol";
 
 import "../lib/BytesUtil.sol";
 import "../lib/MathUint.sol";
 import "../lib/NoDefaultFunc.sol";
+import "../lib/ERC20SafeTransfer.sol";
 
 import "./Data.sol";
 import "./ExchangeDeserializer.sol";
@@ -47,11 +49,12 @@ import "./ExchangeDeserializer.sol";
 ///     https://github.com/jonasshen
 ///     https://github.com/Hephyrius
 contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
-    using MathUint      for uint;
-    using BytesUtil     for bytes;
-    using OrderHelper     for Data.Order;
-    using RingHelper      for Data.Ring;
-    using MiningHelper    for Data.Mining;
+    using MathUint          for uint;
+    using BytesUtil         for bytes;
+    using OrderHelper       for Data.Order;
+    using RingHelper        for Data.Ring;
+    using MiningHelper      for Data.Mining;
+    using ERC20SafeTransfer for address;
 
     address public  lrcTokenAddress             = address(0x0);
     address public  wethTokenAddress            = address(0x0);
@@ -118,6 +121,13 @@ contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
     {
         uint i;
         bytes32[] memory tokenBurnRates;
+
+        (
+            Data.Mining  memory mining,
+            Data.Order[] memory orders,
+            Data.Ring[]  memory rings
+        ) = ExchangeDeserializer.deserialize(lrcTokenAddress, data);
+
         Data.Context memory ctx = Data.Context(
             lrcTokenAddress,
             ITradeDelegate(delegateAddress),
@@ -133,27 +143,22 @@ contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
             0,
             0,
             0,
+            0,
+            new Data.BrokerTransfer[](rings.length * 4),
             0
         );
-
-        // Check if the highest bit of ringIndex is '1'
-        require((ctx.ringIndex >> 63) == 0, REENTRY);
 
         // Set the highest bit of ringIndex to '1' (IN STORAGE!)
         ringIndex = ctx.ringIndex | (1 << 63);
 
-        (
-            Data.Mining  memory mining,
-            Data.Order[] memory orders,
-            Data.Ring[]  memory rings
-        ) = ExchangeDeserializer.deserialize(lrcTokenAddress, data);
+        // Check if the highest bit of ringIndex is '1'
+        require((ctx.ringIndex >> 63) == 0, REENTRY);
 
         // Allocate memory that is used to batch things for all rings
         setupLists(ctx, orders, rings);
 
         for (i = 0; i < orders.length; i++) {
             orders[i].updateHash();
-            orders[i].updateBrokerAndInterceptor(ctx);
         }
 
         batchGetFilledAndCheckCancelled(ctx, orders);
@@ -216,6 +221,8 @@ contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
 
         // Do all token transfers for all rings
         batchTransferTokens(ctx);
+        // Do all broker token transfers for all rings
+        batchBrokerTransferTokens(ctx, orders);
         // Do all fee payments for all rings
         batchPayFees(ctx);
         // Update all order stats
@@ -533,6 +540,36 @@ contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
                         iszero(eq(fill, not(0)))                        // fill != ~uint(0
                     )
                 )
+            }
+        }
+    }
+
+    function batchBrokerTransferTokens(Data.Context memory ctx, Data.Order[] memory orders) internal {
+        for (uint i = 0; i < ctx.numBrokerTransfers; i++) {
+            Data.BrokerTransfer memory transfer = ctx.brokerTransfers[i];
+            Data.Order memory order = orders[transfer.orderIndex];
+          
+            IBrokerDelegate(transfer.broker).brokerRequestAllowance(
+                transfer.owner,
+                order.tokenB,
+                transfer.receivedAmount,
+                order.tokenRecipient,
+                transfer.token,
+                transfer.amount,
+                transfer.recipient,
+                order.transferDataS,
+                transfer.isFee
+            );
+
+            // If the recipient is the broker, do not transfer the tokens
+            // The broker should check for this and internally handle it
+            // if applicable
+            if (transfer.recipient != transfer.broker) {
+                require(transfer.token.safeTransferFrom(
+                    transfer.broker, 
+                    transfer.recipient, 
+                    transfer.amount
+                ), TRANSFER_FAILURE);
             }
         }
     }

--- a/packages/loopring_v2/contracts/impl/TradeDelegate.sol
+++ b/packages/loopring_v2/contracts/impl/TradeDelegate.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/ITradeDelegate.sol";
 import "../lib/Authorizable.sol";

--- a/packages/loopring_v2/contracts/impl/TradeHistory.sol
+++ b/packages/loopring_v2/contracts/impl/TradeHistory.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/ITradeHistory.sol";
 

--- a/packages/loopring_v2/contracts/impl/Voting.sol
+++ b/packages/loopring_v2/contracts/impl/Voting.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../lib/ERC20.sol";
 import "../iface/Errors.sol";

--- a/packages/loopring_v2/contracts/lib/Authorizable.sol
+++ b/packages/loopring_v2/contracts/lib/Authorizable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 

--- a/packages/loopring_v2/contracts/lib/BurnableERC20.sol
+++ b/packages/loopring_v2/contracts/lib/BurnableERC20.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "./ERC20.sol";
 

--- a/packages/loopring_v2/contracts/lib/BytesUtil.sol
+++ b/packages/loopring_v2/contracts/lib/BytesUtil.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title Utility Functions for bytes

--- a/packages/loopring_v2/contracts/lib/Claimable.sol
+++ b/packages/loopring_v2/contracts/lib/Claimable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "./Ownable.sol";
 

--- a/packages/loopring_v2/contracts/lib/ERC20.sol
+++ b/packages/loopring_v2/contracts/lib/ERC20.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title ERC20 Token Interface

--- a/packages/loopring_v2/contracts/lib/ERC20SafeTransfer.sol
+++ b/packages/loopring_v2/contracts/lib/ERC20SafeTransfer.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title ERC20 safe transfer

--- a/packages/loopring_v2/contracts/lib/ERC20Token.sol
+++ b/packages/loopring_v2/contracts/lib/ERC20Token.sol
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 import "./ERC20.sol";

--- a/packages/loopring_v2/contracts/lib/ITransferableMultsig.sol
+++ b/packages/loopring_v2/contracts/lib/ITransferableMultsig.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title ITransferableMultsig

--- a/packages/loopring_v2/contracts/lib/Killable.sol
+++ b/packages/loopring_v2/contracts/lib/Killable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 

--- a/packages/loopring_v2/contracts/lib/MathUint.sol
+++ b/packages/loopring_v2/contracts/lib/MathUint.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title Utility Functions for uint

--- a/packages/loopring_v2/contracts/lib/MultihashUtil.sol
+++ b/packages/loopring_v2/contracts/lib/MultihashUtil.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "./BytesUtil.sol";
 

--- a/packages/loopring_v2/contracts/lib/NoDefaultFunc.sol
+++ b/packages/loopring_v2/contracts/lib/NoDefaultFunc.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 

--- a/packages/loopring_v2/contracts/lib/Ownable.sol
+++ b/packages/loopring_v2/contracts/lib/Ownable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title Ownable

--- a/packages/loopring_v2/contracts/lib/StringUtil.sol
+++ b/packages/loopring_v2/contracts/lib/StringUtil.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 
 /// @title Utility Functions for address

--- a/packages/loopring_v2/contracts/lib/TransferableMultsig.sol
+++ b/packages/loopring_v2/contracts/lib/TransferableMultsig.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 import "./ITransferableMultsig.sol";

--- a/packages/loopring_v2/contracts/test/BytesUtilWrapper.sol
+++ b/packages/loopring_v2/contracts/test/BytesUtilWrapper.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../lib/BytesUtil.sol";
 

--- a/packages/loopring_v2/contracts/test/ContractOrderOwner.sol
+++ b/packages/loopring_v2/contracts/test/ContractOrderOwner.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IOrderCanceller.sol";
 import "../iface/IOrderBook.sol";

--- a/packages/loopring_v2/contracts/test/DeserializerTest.sol
+++ b/packages/loopring_v2/contracts/test/DeserializerTest.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../impl/Data.sol";
 import "../impl/ExchangeDeserializer.sol";
@@ -133,6 +133,7 @@ contract DeserializerTest {
     {
         p = Data.Participation(
             order,
+            0,
             0,
             0,
             0,

--- a/packages/loopring_v2/contracts/test/DummyBrokerDelegate.sol
+++ b/packages/loopring_v2/contracts/test/DummyBrokerDelegate.sol
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Dolomite
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pragma solidity 0.5.7;
+
+import { IBrokerDelegate } from "../iface/IBrokerDelegate.sol";
+import { ERC20 } from "../lib/ERC20.sol"; 
+
+contract DummyBrokerDelegate is IBrokerDelegate {
+
+  function brokerRequestAllowance(
+    address owner, 
+    address receivedToken,
+    uint receivedAmount,
+    address orderTokenRecipient,
+    address requestedToken, 
+    uint requestedAmount, 
+    address requestedRecipient,
+    bytes memory extraOrderData,
+    bool isFee
+  ) public {
+    address payable payableTokenAddress = address(uint160(requestedToken));
+    ERC20 token = ERC20(payableTokenAddress);
+    token.approve(msg.sender, requestedAmount);
+  }
+
+  function brokerBalanceOf(address owner, address tokenAddress) public view returns (uint) {
+    address payable payableTokenAddress = address(uint160(tokenAddress));
+    ERC20 token = ERC20(payableTokenAddress);
+    return token.balanceOf(address(this));
+  }
+}

--- a/packages/loopring_v2/contracts/test/DummyBrokerInterceptor.sol
+++ b/packages/loopring_v2/contracts/test/DummyBrokerInterceptor.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IBrokerInterceptor.sol";
 import "../iface/IRingSubmitter.sol";

--- a/packages/loopring_v2/contracts/test/DummyBurnManager.sol
+++ b/packages/loopring_v2/contracts/test/DummyBurnManager.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IFeeHolder.sol";
 

--- a/packages/loopring_v2/contracts/test/DummyExchange.sol
+++ b/packages/loopring_v2/contracts/test/DummyExchange.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IFeeHolder.sol";
 import "../iface/IRingSubmitter.sol";

--- a/packages/loopring_v2/contracts/test/DummyToken.sol
+++ b/packages/loopring_v2/contracts/test/DummyToken.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "./LRCToken.sol";
 

--- a/packages/loopring_v2/contracts/test/ExchangeWrapper.sol
+++ b/packages/loopring_v2/contracts/test/ExchangeWrapper.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/IRingSubmitter.sol";
 import "../impl/PublicExchangeDeserializer.sol";

--- a/packages/loopring_v2/contracts/test/LRCToken.sol
+++ b/packages/loopring_v2/contracts/test/LRCToken.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../iface/Errors.sol";
 

--- a/packages/loopring_v2/contracts/test/MultihashUtilProxy.sol
+++ b/packages/loopring_v2/contracts/test/MultihashUtilProxy.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../lib/MultihashUtil.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/GTO.sol
+++ b/packages/loopring_v2/contracts/test/tokens/GTO.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/INDA.sol
+++ b/packages/loopring_v2/contracts/test/tokens/INDA.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/INDB.sol
+++ b/packages/loopring_v2/contracts/test/tokens/INDB.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/LRC.sol
+++ b/packages/loopring_v2/contracts/test/tokens/LRC.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/RDN.sol
+++ b/packages/loopring_v2/contracts/test/tokens/RDN.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/REP.sol
+++ b/packages/loopring_v2/contracts/test/tokens/REP.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/contracts/test/tokens/TEST.sol
+++ b/packages/loopring_v2/contracts/test/tokens/TEST.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 import "../../iface/IRingSubmitter.sol";

--- a/packages/loopring_v2/contracts/test/tokens/WETH.sol
+++ b/packages/loopring_v2/contracts/test/tokens/WETH.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity 0.5.2;
+pragma solidity 0.5.7;
 
 import "../DummyToken.sol";
 

--- a/packages/loopring_v2/truffle.js
+++ b/packages/loopring_v2/truffle.js
@@ -15,7 +15,7 @@ module.exports = {
           runs: 10000
         }
       },
-      version: "0.5.2"
+      version: "0.5.7"
     }
   },
   networks: {


### PR DESCRIPTION
* (protocol-2) Re-implements brokers into version 2 of the protocol

* Adds more information to the delegateRequestApproval function

* Minor changes to allow for orders with brokers and tokenRecipients set to the same broker to work properly